### PR TITLE
Add Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,9 @@ jobs:
     strategy:
       matrix:
         os:   [ 'ubuntu', 'macos' ]
-        ruby: [ '2.7', '3.0', '3.1' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}


### PR DESCRIPTION
**Relevant Issues and PRs**

No extant issues or PR.  But Ruby 3.2 has been generally available since Dec 2022, so I'm adding it to the CI matrix.

**Type of Change**  
which type?

- Addition or Improvement of tests
